### PR TITLE
Add ko to goreleaser configuration

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,9 +9,6 @@ permissions:
   contents: write
   packages: write
 
-env:
-  GH_PAT: ${{ secrets.GH_PAT }}
-
 jobs:
   goreleaser:
     runs-on: ubuntu-latest
@@ -32,3 +29,4 @@ jobs:
           args: release --rm-dist
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_PAT: ${{ secrets.GH_PAT }} # used to update Homebrew formula

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,6 @@ jobs:
         with:
           distribution: goreleaser
           version: "~> v2"
-          args: release --clean
+          args: release --rm-dist
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,3 +30,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_PAT: ${{ secrets.GH_PAT }} # used to update Homebrew formula
+          KO_DOCKER_REPO: ghcr.io/${{ github.repository_owner }}/emcee

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -31,3 +31,18 @@ brews:
       name: emcee
       token: "{{ .Env.GH_PAT }}"
     directory: Formula
+
+kos:
+  - platforms:
+      - linux/amd64
+      - linux/arm64
+    tags:
+      - latest
+      - '{{ .Tag }}'
+    bare: true
+    flags:
+      - -trimpath
+    ldflags:
+      - -s -w
+      - -extldflags "-static"
+      - -X main.Version={{.Tag}}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -16,7 +16,7 @@ builds:
     main: ./cmd/emcee
 
 archives:
-  - format: tar.gz
+  - formats: [tar.gz]
     name_template: >-
       {{ .ProjectName }}_
       {{- title .Os }}_


### PR DESCRIPTION
This PR updates our release workflow to also build a Docker image with [ko](https://ko.build) and publish to GitHub Container Registry (ghcr.io)