### PR TITLE
Replace `--auth` option with `--bearer-auth` / `--basic-auth` / `--raw-auth` options

### DIFF
--- a/cmd/emcee/main.go
+++ b/cmd/emcee/main.go
@@ -130,11 +130,6 @@ The spec-path-or-url argument can be:
 					return fmt.Errorf("error creating request: %w", err)
 				}
 
-				// Apply auth header if provided
-				if auth != "" {
-					req.Header.Set("Authorization", auth)
-				}
-
 				// Make HTTP request
 				resp, err := client.Do(req)
 				if err != nil {

--- a/cmd/emcee/main.go
+++ b/cmd/emcee/main.go
@@ -23,13 +23,16 @@ var rootCmd = &cobra.Command{
 	Use:   "emcee [spec-path-or-url]",
 	Short: "Creates an MCP server for an OpenAPI specification",
 	Long: `emcee is a CLI tool that provides an Model Context Protocol (MCP) stdio transport for a given OpenAPI specification.
-It takes an OpenAPI specification path or URL as input and processes JSON-RPC requests
-from stdin, making corresponding API calls and returning JSON-RPC responses to stdout.
+It takes an OpenAPI specification path or URL as input and processes JSON-RPC requests from stdin, making corresponding API calls and returning JSON-RPC responses to stdout.
 
 The spec-path-or-url argument can be:
 - A local file path (e.g. ./openapi.json)
 - An HTTP(S) URL (e.g. https://api.example.com/openapi.json)
-- "-" to read from stdin`,
+- "-" to read from stdin
+
+By default, a GET request with no additional headers is made to the spec URL to download the OpenAPI specification.
+If additional authentication is required to download the specification, you can first download it to a local file using your preferred HTTP client with the necessary authentication headers, and then provide the local file path to emcee.
+`,
 	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// Set up context and signal handling

--- a/cmd/emcee/main.go
+++ b/cmd/emcee/main.go
@@ -16,7 +16,6 @@ import (
 	"github.com/spf13/cobra"
 	"golang.org/x/sync/errgroup"
 
-	"github.com/loopwork-ai/emcee/internal"
 	"github.com/loopwork-ai/emcee/mcp"
 )
 
@@ -77,23 +76,7 @@ The spec-path-or-url argument can be:
 
 			// Set default headers if auth is provided
 			if auth != "" {
-				parts := strings.SplitN(auth, " ", 2)
-				if len(parts) == 1 {
-					// Only token provided, add Bearer prefix
-					logger.Warn("no auth scheme provided, automatically adding 'Bearer' prefix")
-					auth = "Bearer " + parts[0]
-				} else if len(parts) == 2 {
-					// Scheme and token provided, use as-is
-					auth = fmt.Sprintf("%s %s", parts[0], parts[1])
-				}
-
-				headers := http.Header{}
-				headers.Add("Authorization", auth)
-
-				retryClient.HTTPClient.Transport = &internal.HeaderTransport{
-					Base:    retryClient.HTTPClient.Transport,
-					Headers: headers,
-				}
+				opts = append(opts, mcp.WithAuth(auth))
 			}
 
 			client := retryClient.StandardClient()

--- a/internal/http.go
+++ b/internal/http.go
@@ -1,6 +1,12 @@
 package internal
 
-import "net/http"
+import (
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/hashicorp/go-retryablehttp"
+)
 
 // HeaderTransport is a custom RoundTripper that adds default headers to requests
 type HeaderTransport struct {
@@ -8,6 +14,7 @@ type HeaderTransport struct {
 	Headers http.Header
 }
 
+// RoundTrip adds the default headers to the request
 func (t *HeaderTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	for key, values := range t.Headers {
 		for _, value := range values {
@@ -19,4 +26,37 @@ func (t *HeaderTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 		base = http.DefaultTransport
 	}
 	return base.RoundTrip(req)
+}
+
+// RetryableClient returns a new http.Client with a retryablehttp.Client
+// configured with the provided parameters.
+func RetryableClient(retries int, timeout time.Duration, rps int, logger interface{}) (*http.Client, error) {
+	if retries < 0 {
+		return nil, fmt.Errorf("retries must be greater than 0")
+	}
+	if timeout < 0 {
+		return nil, fmt.Errorf("timeout must be greater than 0")
+	}
+	if rps < 0 {
+		return nil, fmt.Errorf("rps must be greater than 0")
+	}
+
+	retryClient := retryablehttp.NewClient()
+	retryClient.RetryMax = retries
+	retryClient.RetryWaitMin = 1 * time.Second
+	retryClient.RetryWaitMax = 30 * time.Second
+	retryClient.HTTPClient.Timeout = timeout
+	retryClient.Logger = logger
+	if rps > 0 {
+		retryClient.Backoff = func(min, max time.Duration, attemptNum int, resp *http.Response) time.Duration {
+			// Ensure we wait at least 1/rps between requests
+			minWait := time.Second / time.Duration(rps)
+			if min < minWait {
+				min = minWait
+			}
+			return retryablehttp.DefaultBackoff(min, max, attemptNum, resp)
+		}
+	}
+
+	return retryClient.StandardClient(), nil
 }


### PR DESCRIPTION
Follow up to #14 

Instead of automatically assuming and prepending `Bearer ` prefix when raw token is passed to `--auth` flag, users can specify `--bearer-auth` flag.

This PR also refactors auth functionality, and makes it so that OpenAPI specifications are requested without credentials. 