### PR TITLE
Add `-s`/`--silent` flag

### DIFF
--- a/cmd/emcee/main.go
+++ b/cmd/emcee/main.go
@@ -45,11 +45,18 @@ If additional authentication is required to download the specification, you can 
 		g, ctx := errgroup.WithContext(ctx)
 
 		// Set up logger
-		logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{
-			Level: slog.LevelDebug,
-		}))
-		if !verbose {
+		var logger *slog.Logger
+		switch {
+		case silent:
 			logger = slog.New(slog.NewTextHandler(io.Discard, nil))
+		case verbose:
+			logger = slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{
+				Level: slog.LevelDebug,
+			}))
+		default:
+			logger = slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{
+				Level: slog.LevelInfo,
+			}))
 		}
 
 		g.Go(func() error {
@@ -188,6 +195,7 @@ var (
 	rps     int
 
 	verbose bool
+	silent  bool
 
 	version = "dev"
 	commit  = "none"
@@ -204,7 +212,9 @@ func init() {
 	rootCmd.Flags().DurationVar(&timeout, "timeout", 60*time.Second, "HTTP request timeout")
 	rootCmd.Flags().IntVarP(&rps, "rps", "r", 0, "Maximum requests per second (0 for no limit)")
 
-	rootCmd.Flags().BoolVarP(&verbose, "verbose", "v", false, "Enable verbose logging to stderr")
+	rootCmd.Flags().BoolVarP(&verbose, "verbose", "v", false, "Enable debug level logging to stderr")
+	rootCmd.Flags().BoolVarP(&silent, "silent", "s", false, "Disable all logging")
+	rootCmd.MarkFlagsMutuallyExclusive("verbose", "silent")
 
 	rootCmd.Version = fmt.Sprintf("%s (commit: %s, built at: %s)", version, commit, date)
 }

--- a/mcp/server.go
+++ b/mcp/server.go
@@ -146,7 +146,7 @@ func NewServer(opts ...ServerOption) (*Server, error) {
 func (s *Server) HandleRequest(request jsonrpc.Request) jsonrpc.Response {
 	if s.logger != nil {
 		reqJSON, _ := json.MarshalIndent(request, "", "  ")
-		s.logger.Info("incoming request",
+		s.logger.Debug("incoming request",
 			"request", string(reqJSON),
 			"method", request.Method)
 	}
@@ -170,7 +170,7 @@ func (s *Server) HandleRequest(request jsonrpc.Request) jsonrpc.Response {
 
 	if s.logger != nil {
 		respJSON, _ := json.MarshalIndent(response, "", "  ")
-		s.logger.Info("outgoing response",
+		s.logger.Debug("outgoing response",
 			"response", string(respJSON))
 	}
 


### PR DESCRIPTION
Currently, logging to stderr is controlled by a `-v`/`--verbose` flag (#2). By default, logging is disabled unless this option is set.

This PR does the following:

- Changes the default behavior to log at `INFO` level
- Adds a `-s/--silent` flag to disable all logging
- Updates levels for existing log statements
- Adds more logging statements