### PR TITLE
Add support for 1Password secret references

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,14 +161,33 @@ it starts a program that listens on stdin,
 outputs to stdout,
 and logs to stderr.
 
+### Authentication
+
+For APIs that require authentication,
+emcee supports several authentication methods:
+
+- Bearer tokens (`--bearer-auth`)
+- Basic auth (`--basic-auth`)
+- Raw `Authorization` header values (`--raw-auth`)
+
+These authentication values can be provided directly
+or as [1Password secret references][secret-reference-syntax].
+
+When using 1Password references:
+- Use the format `op://vault/item/field`
+  (e.g. `--bearer-auth="op://Development/Weather API/token"`)
+- Ensure the 1Password CLI (`op`) is installed and available in your `PATH`
+- Sign in to 1Password before running `emcee`
+- The secret will be securely retrieved at runtime using the 1Password CLI
+
+### JSON-RPC
+
 You can interact directly with the provided MCP server
 by sending JSON-RPC requests.
 
 > [!NOTE]
 > emcee provides only MCP tool capabilities.
 > Other features like resources, prompts, and sampling aren't yet supported.
-
-### Example JSON-RPC Calls
 
 #### List Tools
 
@@ -280,3 +299,4 @@ emcee is licensed under the Apache License, Version 2.0.
 [mcp-servers]: https://modelcontextprotocol.io/examples
 [openapi]: https://openapi.org
 [releases]: https://github.com/loopwork-ai/emcee/releases
+[secret-reference-syntax]: https://developer.1password.com/docs/cli/secret-reference-syntax/

--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ When using 1Password references:
 }
 ```
 
-![1Password Access Requested](https://github.com/user-attachments/assets/d639fd7c-f3bf-477c-9eb7-229285b36f7d)
+<img src="https://github.com/user-attachments/assets/d639fd7c-f3bf-477c-9eb7-229285b36f7d" alt="1Password Access Requested" width="512">
 
 ### JSON-RPC
 

--- a/README.md
+++ b/README.md
@@ -166,19 +166,36 @@ and logs to stderr.
 For APIs that require authentication,
 emcee supports several authentication methods:
 
-- Bearer tokens (`--bearer-auth`)
-- Basic auth (`--basic-auth`)
-- Raw `Authorization` header values (`--raw-auth`)
+| Authentication Type | Example Usage | Resulting Header |
+|------------------------|---------------|----------------------------|
+| **Bearer Token** | `--bearer-auth="abc123"` | `Authorization: Bearer abc123` |
+| **Basic Auth** | `--basic-auth="user:pass"` | `Authorization: Basic dXNlcjpwYXNz` |
+| **Raw Value** | `--raw-auth="Custom xyz789"` | `Authorization: Custom xyz789` |
 
 These authentication values can be provided directly
 or as [1Password secret references][secret-reference-syntax].
 
 When using 1Password references:
 - Use the format `op://vault/item/field`
-  (e.g. `--bearer-auth="op://Development/Weather API/token"`)
+  (e.g. `--bearer-auth="op://Shared/X/credential"`)
 - Ensure the 1Password CLI (`op`) is installed and available in your `PATH`
-- Sign in to 1Password before running `emcee`
-- The secret will be securely retrieved at runtime using the 1Password CLI
+- Sign in to 1Password before running `emcee` or launching Claude Desktop
+
+```json
+{
+  "mcpServers": {
+    "twitter": {
+      "command": "emcee",
+      "args": [
+        "--bearer-auth=op://shared/x/credential",
+        "https://api.twitter.com/2/openapi.json"
+      ]
+    }
+  }
+}
+```
+
+![1Password Access Requested](https://github.com/user-attachments/assets/d639fd7c-f3bf-477c-9eb7-229285b36f7d)
 
 ### JSON-RPC
 

--- a/internal/secret.go
+++ b/internal/secret.go
@@ -1,0 +1,36 @@
+package internal
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+// ResolveSecretReference attempts to resolve a 1Password secret reference (e.g. op://vault/item/field)
+// Returns the resolved value and whether it was a secret reference
+func ResolveSecretReference(ctx context.Context, value string) (string, bool, error) {
+	if !strings.HasPrefix(value, "op://") {
+		return value, false, nil
+	}
+
+	// Check if op CLI is available
+	if _, err := exec.LookPath("op"); err != nil {
+		return "", true, fmt.Errorf("1Password CLI (op) not found in PATH: %w", err)
+	}
+
+	// Create command to read secret
+	cmd := exec.CommandContext(ctx, "op", "read", value)
+	output, err := cmd.Output()
+	if err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			return "", true, fmt.Errorf("failed to read secret from 1Password: %s", string(exitErr.Stderr))
+		}
+		return "", true, fmt.Errorf("failed to read secret from 1Password: %w", err)
+	}
+
+	// Trim any whitespace/newlines from the output
+	return strings.TrimSpace(string(output)), true, nil
+}

--- a/internal/secret.go
+++ b/internal/secret.go
@@ -8,6 +8,13 @@ import (
 	"strings"
 )
 
+var (
+	// Command is a variable that allows overriding the command creation for testing
+	CommandContext = exec.CommandContext
+	// LookPath is a variable that allows overriding the lookup behavior for testing
+	LookPath = exec.LookPath
+)
+
 // ResolveSecretReference attempts to resolve a 1Password secret reference (e.g. op://vault/item/field)
 // Returns the resolved value and whether it was a secret reference
 func ResolveSecretReference(ctx context.Context, value string) (string, bool, error) {
@@ -16,12 +23,12 @@ func ResolveSecretReference(ctx context.Context, value string) (string, bool, er
 	}
 
 	// Check if op CLI is available
-	if _, err := exec.LookPath("op"); err != nil {
+	if _, err := LookPath("op"); err != nil {
 		return "", true, fmt.Errorf("1Password CLI (op) not found in PATH: %w", err)
 	}
 
 	// Create command to read secret
-	cmd := exec.CommandContext(ctx, "op", "read", value)
+	cmd := CommandContext(ctx, "op", "read", value)
 	output, err := cmd.Output()
 	if err != nil {
 		var exitErr *exec.ExitError

--- a/internal/secret_test.go
+++ b/internal/secret_test.go
@@ -1,0 +1,106 @@
+package internal
+
+import (
+	"context"
+	"os/exec"
+	"testing"
+)
+
+func TestResolveSecretReference(t *testing.T) {
+	// Save the original functions and restore them after the test
+	originalCommand := CommandContext
+	originalLookPath := LookPath
+	t.Cleanup(func() {
+		CommandContext = originalCommand
+		LookPath = originalLookPath
+	})
+
+	tests := []struct {
+		name               string
+		input              string
+		mockCommandContext func(ctx context.Context, name string, args ...string) *exec.Cmd
+		mockLookPath       func(string) (string, error)
+		wantValue          string
+		wantSecret         bool
+		wantErr            bool
+	}{
+		{
+			name:       "non-secret value",
+			input:      "regular-value",
+			wantValue:  "regular-value",
+			wantSecret: false,
+		},
+		{
+			name:  "successful secret resolution",
+			input: "op://vault/item/field",
+			mockLookPath: func(string) (string, error) {
+				return "/usr/local/bin/op", nil
+			},
+			mockCommandContext: func(ctx context.Context, name string, args ...string) *exec.Cmd {
+				return exec.CommandContext(ctx, "echo", "secret-value")
+			},
+			wantValue:  "secret-value",
+			wantSecret: true,
+		},
+		{
+			name:  "op CLI not found",
+			input: "op://vault/item/field",
+			mockLookPath: func(string) (string, error) {
+				return "", exec.ErrNotFound
+			},
+			wantValue:  "",
+			wantSecret: true,
+			wantErr:    true,
+		},
+		{
+			name:  "op command execution failed",
+			input: "op://vault/item/field",
+			mockLookPath: func(string) (string, error) {
+				return "/usr/local/bin/op", nil
+			},
+			mockCommandContext: func(ctx context.Context, name string, args ...string) *exec.Cmd {
+				// Return a command that will fail
+				return exec.CommandContext(ctx, "false")
+			},
+			wantValue:  "",
+			wantSecret: true,
+			wantErr:    true,
+		},
+		{
+			name:       "empty input",
+			input:      "",
+			wantValue:  "",
+			wantSecret: false,
+		},
+		{
+			name:       "malformed op reference",
+			input:      "op://invalid",
+			wantValue:  "",
+			wantSecret: true,
+			wantErr:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.mockCommandContext != nil {
+				CommandContext = tt.mockCommandContext
+			}
+			if tt.mockLookPath != nil {
+				LookPath = tt.mockLookPath
+			}
+
+			got, isSecret, err := ResolveSecretReference(context.Background(), tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ResolveSecretReference() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.wantValue {
+				t.Errorf("ResolveSecretReference() got = %v, want %v", got, tt.wantValue)
+			}
+			if isSecret != tt.wantSecret {
+				t.Errorf("ResolveSecretReference() isSecret = %v, want %v", isSecret, tt.wantSecret)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR adds support for using 1Password secret references (`op://vault/item/field`) with emcee's authentication flags (`--bearer-auth`, `--basic-auth`, `--raw-auth`). This allows users to securely store and retrieve API credentials from their 1Password vaults at runtime. 


```json
{
  "mcpServers": {
    "twitter": {
      "command": "emcee",
      "args": [
        "--bearer-auth=op://shared/x/credential",
        "https://api.twitter.com/2/openapi.json"
      ]
    }
  }
}
```

<img width="512" alt="Screenshot 2025-01-27 at 03 52 07" src="https://github.com/user-attachments/assets/d639fd7c-f3bf-477c-9eb7-229285b36f7d" />


It also updates documentation in both the CLI help text and README accordingly.