### PR TITLE
Handle requests with `initialize` method explicitly

### DIFF
--- a/mcp/server.go
+++ b/mcp/server.go
@@ -153,7 +153,8 @@ func (s *Server) HandleRequest(request jsonrpc.Request) *jsonrpc.Response {
 		s.logger.Info("handling request", "method", request.Method)
 	}
 
-	if strings.HasPrefix(request.Method, "notifications/") {
+	// Handle notifications first
+	if strings.HasPrefix(request.Method, "notifications/") || request.Method == "initialized" {
 		s.logger.Info("received notification", "method", request.Method)
 		return nil
 	}
@@ -215,18 +216,6 @@ func handleRequest[Req, Resp any](request jsonrpc.Request, handler func(*Req) (*
 	}
 
 	return jsonrpc.NewResponse(request.ID, result, nil)
-}
-
-// handleNotification is a helper to unmarshal params and call a notification handler
-func handleNotification[Req any](request jsonrpc.Request, handler func(*Req)) {
-	var req Req
-	if request.Params != nil {
-		if err := json.Unmarshal(request.Params, &req); err != nil {
-			return
-		}
-	}
-
-	handler(&req)
 }
 
 func (s *Server) handleInitialize(request *InitializeRequest) (*InitializeResponse, error) {

--- a/mcp/server_test.go
+++ b/mcp/server_test.go
@@ -10,6 +10,9 @@ import (
 	"strings"
 	"testing"
 
+	"io"
+	"log/slog"
+
 	"github.com/loopwork-ai/emcee/internal"
 	"github.com/loopwork-ai/emcee/jsonrpc"
 	"github.com/stretchr/testify/assert"
@@ -929,4 +932,22 @@ func TestFindOperationByToolName(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestHandleInitializedNotification(t *testing.T) {
+	// Create a test server with a logger
+	server, ts := setupTestServer(t)
+	defer ts.Close()
+
+	// Add a logger to the server
+	server.logger = slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	// Create an initialized notification
+	notification := jsonrpc.NewRequest("initialized", nil, 1)
+
+	// Handle the notification
+	response := server.HandleRequest(notification)
+
+	// Verify that notifications don't generate a response
+	assert.Nil(t, response, "notifications should not generate a response")
 }


### PR DESCRIPTION
Follow-up to #45 